### PR TITLE
Fix re-entrant model boot on Laravel 11+

### DIFF
--- a/src/Embeddable.php
+++ b/src/Embeddable.php
@@ -17,9 +17,22 @@ trait Embeddable
     {
         static::addGlobalScope(new EmbeddableScope);
 
-        static::observe(new ModelObserver);
+        $whenBootedCallback = function () {
+            static::observe(new ModelObserver);
 
-        (new static)->registerEmbeddableMacros();
+            (new static)->registerEmbeddableMacros();
+        };
+
+        // Registering the observer or instantiating the model while the model
+        // is still booting triggers a re-entrant boot, which Laravel 11+
+        // rejects with a LogicException. Defer that work until the model has
+        // finished booting; fall back to running it immediately on older
+        // versions that lack the whenBooted() hook.
+        if (method_exists(static::class, 'whenBooted')) {
+            static::whenBooted($whenBootedCallback);
+        } else {
+            $whenBootedCallback();
+        }
     }
 
     /**

--- a/src/Embeddable.php
+++ b/src/Embeddable.php
@@ -2,8 +2,10 @@
 
 namespace Vormkracht10\Embedding;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Collection as BaseCollection;
 
 trait Embeddable
@@ -143,7 +145,7 @@ trait Embeddable
     /**
      * Modify the collection of models being made embeddable.
      *
-     * @return \Illuminate\Support\Collection
+     * @return Collection
      */
     public function makeEmbeddableUsing(BaseCollection $models)
     {
@@ -153,7 +155,7 @@ trait Embeddable
     /**
      * Modify the query used to retrieve models when making all of the models embeddable.
      *
-     * @return \Illuminate\Database\Eloquent\Builder
+     * @return Builder
      */
     protected function makeAllEmbeddableUsing(EloquentBuilder $query)
     {

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -3,6 +3,7 @@
 namespace Vormkracht10\Embedding;
 
 use Illuminate\Support\Manager;
+use Vormkracht10\Embedding\Engines\EngineInterface;
 use Vormkracht10\Embedding\Engines\NullEngine;
 use Vormkracht10\Embedding\Engines\OpenAiEngine;
 
@@ -12,7 +13,7 @@ class EngineManager extends Manager
      * Get a driver instance.
      *
      * @param  string|null  $name
-     * @return \Vormkracht10\Embedding\Engines\EngineInterface
+     * @return EngineInterface
      */
     public function engine($name = null)
     {
@@ -22,7 +23,7 @@ class EngineManager extends Manager
     /**
      * Create an Algolia engine instance.
      *
-     * @return \Vormkracht10\Embedding\Engines\OpenAiEngine
+     * @return OpenAiEngine
      */
     public function createOpenAiDriver()
     {

--- a/src/Engines/NullEngine.php
+++ b/src/Engines/NullEngine.php
@@ -2,6 +2,8 @@
 
 namespace Vormkracht10\Embedding\Engines;
 
+use Illuminate\Database\Eloquent\Collection;
+
 class NullEngine implements EngineInterface
 {
     public function __construct() {}
@@ -14,7 +16,7 @@ class NullEngine implements EngineInterface
     /**
      * Update the given model
      *
-     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @param  Collection  $models
      * @return void
      */
     public function update($models) {}
@@ -22,7 +24,7 @@ class NullEngine implements EngineInterface
     /**
      * Remove the given model from the index.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @param  Collection  $models
      * @return void
      */
     public function delete($models) {}

--- a/src/Engines/OpenAiEngine.php
+++ b/src/Engines/OpenAiEngine.php
@@ -2,6 +2,8 @@
 
 namespace Vormkracht10\Embedding\Engines;
 
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
@@ -28,7 +30,7 @@ class OpenAiEngine implements EngineInterface
     /**
      * Update the given model
      *
-     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @param  Collection  $models
      * @return void
      */
     public function update($models)
@@ -107,7 +109,7 @@ class OpenAiEngine implements EngineInterface
     /**
      * Remove the given model from the index.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @param  Collection  $models
      * @return void
      */
     public function delete($models)
@@ -123,7 +125,7 @@ class OpenAiEngine implements EngineInterface
     /**
      * Determine if the given model uses soft deletes.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  Model  $model
      * @return bool
      */
     protected function usesSoftDelete($model)

--- a/src/Events/ModelsFlushed.php
+++ b/src/Events/ModelsFlushed.php
@@ -2,19 +2,21 @@
 
 namespace Vormkracht10\Embedding\Events;
 
+use Illuminate\Database\Eloquent\Collection;
+
 class ModelsFlushed
 {
     /**
      * The model collection.
      *
-     * @var \Illuminate\Database\Eloquent\Collection
+     * @var Collection
      */
     public $models;
 
     /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @param  Collection  $models
      * @return void
      */
     public function __construct($models)

--- a/src/Events/ModelsImported.php
+++ b/src/Events/ModelsImported.php
@@ -2,19 +2,21 @@
 
 namespace Vormkracht10\Embedding\Events;
 
+use Illuminate\Database\Eloquent\Collection;
+
 class ModelsImported
 {
     /**
      * The model collection.
      *
-     * @var \Illuminate\Database\Eloquent\Collection
+     * @var Collection
      */
     public $models;
 
     /**
      * Create a new event instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @param  Collection  $models
      * @return void
      */
     public function __construct($models)

--- a/src/Jobs/MakeEmbeddable.php
+++ b/src/Jobs/MakeEmbeddable.php
@@ -4,6 +4,7 @@ namespace Vormkracht10\Embedding\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Queue\SerializesModels;
 
 class MakeEmbeddable implements ShouldQueue
@@ -13,14 +14,14 @@ class MakeEmbeddable implements ShouldQueue
     /**
      * The models to be made embeddable.
      *
-     * @var \Illuminate\Database\Eloquent\Collection
+     * @var Collection
      */
     public $models;
 
     /**
      * Create a new job instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @param  Collection  $models
      * @return void
      */
     public function __construct($models)

--- a/src/Jobs/RemoveFromEmbed.php
+++ b/src/Jobs/RemoveFromEmbed.php
@@ -3,7 +3,9 @@
 namespace Vormkracht10\Embedding\Jobs;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Database\ModelIdentifier;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Queue\SerializesModels;
 
 class RemoveFromEmbed implements ShouldQueue
@@ -13,14 +15,14 @@ class RemoveFromEmbed implements ShouldQueue
     /**
      * The models to be removed from the search index.
      *
-     * @var \Vormkracht10\Embedding\Jobs\RemoveableEmbedCollection
+     * @var RemoveableEmbedCollection
      */
     public $models;
 
     /**
      * Create a new job instance.
      *
-     * @param  \Illuminate\Database\Eloquent\Collection  $models
+     * @param  Collection  $models
      * @return void
      */
     public function __construct($models)
@@ -43,8 +45,8 @@ class RemoveFromEmbed implements ShouldQueue
     /**
      * Restore a queueable collection instance.
      *
-     * @param  \Illuminate\Contracts\Database\ModelIdentifier  $value
-     * @return \Vormkracht10\Embedding\Jobs\RemoveableEmbedCollection
+     * @param  ModelIdentifier  $value
+     * @return RemoveableEmbedCollection
      */
     protected function restoreCollection($value)
     {

--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -3,6 +3,7 @@
 namespace Vormkracht10\Embedding;
 
 use Closure;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Facades\Config;
 
@@ -77,7 +78,7 @@ class ModelObserver
     /**
      * Handle the saved event for the model.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  Model  $model
      * @return void
      */
     public function saved($model)
@@ -98,7 +99,7 @@ class ModelObserver
     /**
      * Handle the deleted event for the model.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  Model  $model
      * @return void
      */
     public function deleted($model)
@@ -119,7 +120,7 @@ class ModelObserver
     /**
      * Handle the force deleted event for the model.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  Model  $model
      * @return void
      */
     public function forceDeleted($model)
@@ -134,7 +135,7 @@ class ModelObserver
     /**
      * Handle the restored event for the model.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  Model  $model
      * @return void
      */
     public function restored($model)
@@ -163,7 +164,7 @@ class ModelObserver
     /**
      * Determine if the given model uses soft deletes.
      *
-     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  Model  $model
      * @return bool
      */
     protected function usesSoftDelete($model)

--- a/tests/EmbeddableBootTest.php
+++ b/tests/EmbeddableBootTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Support\Collection;
+use Vormkracht10\Embedding\Tests\Models\EmbeddableTestModel;
+
+it('boots a model using the Embeddable trait without a re-entrant boot error', function () {
+    // Booting the model runs bootEmbeddable(). On Laravel 11+ registering the
+    // observer or instantiating the model while it is still booting throws a
+    // LogicException ("... while it is being booted."). Instantiating here
+    // forces the boot and proves it no longer happens.
+    $model = new EmbeddableTestModel;
+
+    expect($model)->toBeInstanceOf(EmbeddableTestModel::class);
+});
+
+it('registers the embeddable collection macros once the model has booted', function () {
+    new EmbeddableTestModel;
+
+    expect(Collection::hasMacro('embeddable'))->toBeTrue()
+        ->and(Collection::hasMacro('unembeddable'))->toBeTrue();
+});

--- a/tests/Models/EmbeddableTestModel.php
+++ b/tests/Models/EmbeddableTestModel.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Vormkracht10\Embedding\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Vormkracht10\Embedding\Embeddable;
+
+class EmbeddableTestModel extends Model
+{
+    use Embeddable;
+
+    protected $table = 'embeddable_test_models';
+
+    protected $guarded = [];
+}


### PR DESCRIPTION
## Problem

`v0.1.0` widened the framework constraint so the package *installs* on Laravel 11/12/13, but the **runtime incompatibility was unchanged**. `Embeddable::bootEmbeddable()` registers the observer and instantiates the model (`new static` for the collection macros) *while the model is still booting*:

```php
public static function bootEmbeddable()
{
    static::addGlobalScope(new EmbeddableScope);
    static::observe(new ModelObserver);          // observe() does `new static` internally
    (new static)->registerEmbeddableMacros();    // instantiates during boot
}
```

Laravel 11+ added a re-entrancy guard in `Model::bootIfNotBooted()` that throws when a model is instantiated mid-boot:

```
LogicException: The [Illuminate\Database\Eloquent\Model::bootIfNotBooted] method
may not be called on model [...] while it is being booted.
```

So **any model using the `Embeddable` trait fails to boot** on Laravel 11, 12 and 13.

## Fix

Defer the observer registration and macro setup into a `whenBooted()` callback so they run *after* the model finishes booting (the guard is cleared by then), with an immediate-execution fallback for older Laravel versions that lack the hook. This mirrors how Laravel Scout solves the identical problem.

## Test

Adds `EmbeddableBootTest`, which boots a model that uses the trait. It reproduces the `LogicException` against the old `bootEmbeddable()` and passes with the fix. The previous suite never instantiated a model using the trait, which is why the bug shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)