### PR TITLE
Rename organization from vormkracht10 to ux-nl

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: vormkracht10
+github: ux-nl

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: Ask a question
-    url: https://github.com/vormkracht10/laravel-embeddings/discussions/new?category=q-a
+    url: https://github.com/ux-nl/laravel-embeddings/discussions/new?category=q-a
     about: Ask the community for help
   - name: Request a feature
-    url: https://github.com/vormkracht10/laravel-embeddings/discussions/new?category=ideas
+    url: https://github.com/ux-nl/laravel-embeddings/discussions/new?category=ideas
     about: Share ideas for new features
   - name: Report a security issue
-    url: https://github.com/vormkracht10/laravel-embeddings/security/policy
+    url: https://github.com/ux-nl/laravel-embeddings/security/policy
     about: Learn how to notify us for sensitive bugs

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) vormkracht10 <developers@vormkracht10.nl>
+Copyright (c) UX <developers@ux.nl>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Create embeddings for your Eloquent models to use with OpenAI
 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/vormkracht10/laravel-embeddings.svg?style=flat-square)](https://packagist.org/packages/vormkracht10/laravel-embeddings)
-[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/vormkracht10/laravel-embeddings/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/vormkracht10/laravel-embeddings/actions?query=workflow%3Arun-tests+branch%3Amain)
-[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/vormkracht10/laravel-embeddings/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/vormkracht10/laravel-embeddings/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
-[![Total Downloads](https://img.shields.io/packagist/dt/vormkracht10/laravel-embeddings.svg?style=flat-square)](https://packagist.org/packages/vormkracht10/laravel-embeddings)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/ux-nl/laravel-embeddings.svg?style=flat-square)](https://packagist.org/packages/ux-nl/laravel-embeddings)
+[![GitHub Tests Action Status](https://img.shields.io/github/actions/workflow/status/ux-nl/laravel-embeddings/run-tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/ux-nl/laravel-embeddings/actions?query=workflow%3Arun-tests+branch%3Amain)
+[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/ux-nl/laravel-embeddings/fix-php-code-style-issues.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/ux-nl/laravel-embeddings/actions?query=workflow%3A"Fix+PHP+code+style+issues"+branch%3Amain)
+[![Total Downloads](https://img.shields.io/packagist/dt/ux-nl/laravel-embeddings.svg?style=flat-square)](https://packagist.org/packages/ux-nl/laravel-embeddings)
 
 OpenAI's text embeddings measure the relatedness of text strings. Using this package you can save embeddings automatically for your Eloquent model in a PostgreSQL vector database. To use the embeddings in your AI requests to the OpenAI API endpoints.
 
@@ -12,7 +12,7 @@ OpenAI's text embeddings measure the relatedness of text strings. Using this pac
 You can install the package via composer:
 
 ```bash
-composer require vormkracht10/laravel-embeddings
+composer require ux-nl/laravel-embeddings
 ```
 
 You can publish and run the migrations with:
@@ -74,7 +74,7 @@ OPENAI_API_KEY=
 // Add the Embeddable trait to your Model(s).
 class MyModel {
     use Embeddable {
-        \Laravel\Scout\Searchable::usesSoftDelete insteadof \Vormkracht10\Embedding\Embeddable;
+        \Laravel\Scout\Searchable::usesSoftDelete insteadof \UX\Embedding\Embeddable;
     }
 }
 
@@ -109,7 +109,7 @@ Please review [our security policy](../../security/policy) on how to report secu
 
 ## Credits
 
--   [Vormkracht10](https://github.com/vormkracht10)
+-   [UX](https://github.com/ux-nl)
 -   [All Contributors](../../contributors)
 
 ## License

--- a/composer.json
+++ b/composer.json
@@ -1,16 +1,16 @@
 {
-    "name": "vormkracht10/laravel-embeddings",
+    "name": "ux-nl/laravel-embeddings",
     "description": "Create embeddings for your Eloquent models to use with OpenAI",
     "keywords": [
-        "vormkracht10",
+        "ux-nl",
         "laravel"
     ],
-    "homepage": "https://github.com/vormkracht10/laravel-embeddings",
+    "homepage": "https://github.com/ux-nl/laravel-embeddings",
     "license": "MIT",
     "authors": [
         {
-            "name": "Vormkracht10",
-            "email": "developers@vormkracht10.nl",
+            "name": "UX",
+            "email": "developers@ux.nl",
             "role": "Developer"
         }
     ],
@@ -32,13 +32,13 @@
     },
     "autoload": {
         "psr-4": {
-            "Vormkracht10\\Embedding\\": "src/",
-            "Vormkracht10\\Embedding\\Database\\Factories\\": "database/factories/"
+            "UX\\Embedding\\": "src/",
+            "UX\\Embedding\\Database\\Factories\\": "database/factories/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Vormkracht10\\Embedding\\Tests\\": "tests/"
+            "UX\\Embedding\\Tests\\": "tests/"
         }
     },
     "scripts": {
@@ -58,10 +58,10 @@
     "extra": {
         "laravel": {
             "providers": [
-                "Vormkracht10\\Embedding\\EmbeddingServiceProvider"
+                "UX\\Embedding\\EmbeddingServiceProvider"
             ],
             "aliases": {
-                "Embedding": "Vormkracht10\\Embedding\\Facades\\Embedding"
+                "Embedding": "UX\\Embedding\\Facades\\Embedding"
             }
         }
     },

--- a/config/embeddings.php
+++ b/config/embeddings.php
@@ -1,6 +1,6 @@
 <?php
 
-// config for Vormkracht10/Embeddings
+// config for UX/Embeddings
 return [
     'enabled' => env('EMBEDDINGS_ENABLED', true),
     'driver' => env('EMBEDDINGS_DRIVER', 'null'), // 'null' / 'openai'

--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Vormkracht10\Embedding\Database\Factories;
+namespace UX\Embedding\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,7 +7,7 @@ parameters:
 			path: config/embeddings.php
 
 		-
-			message: '#^Trait Vormkracht10\\Embedding\\Embeddable is used zero times and is not analysed\.$#'
+			message: '#^Trait UX\\Embedding\\Embeddable is used zero times and is not analysed\.$#'
 			identifier: trait.unused
 			count: 1
 			path: src/Embeddable.php
@@ -49,7 +49,7 @@ parameters:
 			path: src/Engines/OpenAiEngine.php
 
 		-
-			message: '#^Class Vormkracht10\\Embedding\\LaravelEmbed not found\.$#'
+			message: '#^Class UX\\Embedding\\LaravelEmbed not found\.$#'
 			identifier: class.notFound
 			count: 1
 			path: src/Facades/LaravelEmbed.php
@@ -67,13 +67,13 @@ parameters:
 			path: src/Jobs/RemoveFromEmbed.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Support\\HigherOrderCollectionProxy\<string, Illuminate\\Database\\Eloquent\\Model, static\(Vormkracht10\\Embedding\\Jobs\\RemoveableEmbedCollection\)\>\:\:getEmbedKey\(\)\.$#'
+			message: '#^Call to an undefined method Illuminate\\Support\\HigherOrderCollectionProxy\<string, Illuminate\\Database\\Eloquent\\Model, static\(UX\\Embedding\\Jobs\\RemoveableEmbedCollection\)\>\:\:getEmbedKey\(\)\.$#'
 			identifier: method.notFound
 			count: 1
 			path: src/Jobs/RemoveableEmbedCollection.php
 
 		-
-			message: '#^Class Vormkracht10\\Embedding\\Jobs\\Embeddable not found\.$#'
+			message: '#^Class UX\\Embedding\\Jobs\\Embeddable not found\.$#'
 			identifier: class.notFound
 			count: 1
 			path: src/Jobs/RemoveableEmbedCollection.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,7 +16,7 @@
     backupStaticProperties="false"
 >
     <testsuites>
-        <testsuite name="Vormkracht10 Test Suite">
+        <testsuite name="UX Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>

--- a/src/Commands/ImportCommand.php
+++ b/src/Commands/ImportCommand.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Vormkracht10\Embedding\Commands;
+namespace UX\Embedding\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Events\Dispatcher;
-use Vormkracht10\Embedding\Events\ModelsImported;
+use UX\Embedding\Events\ModelsImported;
 
 class ImportCommand extends Command
 {

--- a/src/Embed.php
+++ b/src/Embed.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Vormkracht10\Embedding;
+namespace UX\Embedding;
 
-use Vormkracht10\Embedding\Jobs\MakeEmbeddable;
-use Vormkracht10\Embedding\Jobs\RemoveFromEmbed;
+use UX\Embedding\Jobs\MakeEmbeddable;
+use UX\Embedding\Jobs\RemoveFromEmbed;
 
 class Embed
 {

--- a/src/Embeddable.php
+++ b/src/Embeddable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Vormkracht10\Embedding;
+namespace UX\Embedding;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;

--- a/src/EmbeddableScope.php
+++ b/src/EmbeddableScope.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Vormkracht10\Embedding;
+namespace UX\Embedding;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Scope;
-use Vormkracht10\Embedding\Events\ModelsFlushed;
-use Vormkracht10\Embedding\Events\ModelsImported;
+use UX\Embedding\Events\ModelsFlushed;
+use UX\Embedding\Events\ModelsImported;
 
 class EmbeddableScope implements Scope
 {

--- a/src/EmbeddingServiceProvider.php
+++ b/src/EmbeddingServiceProvider.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Vormkracht10\Embedding;
+namespace UX\Embedding;
 
 use Illuminate\Support\ServiceProvider;
-use Vormkracht10\Embedding\Commands\ImportCommand;
+use UX\Embedding\Commands\ImportCommand;
 
 class EmbeddingServiceProvider extends ServiceProvider
 {

--- a/src/EngineManager.php
+++ b/src/EngineManager.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Vormkracht10\Embedding;
+namespace UX\Embedding;
 
 use Illuminate\Support\Manager;
-use Vormkracht10\Embedding\Engines\EngineInterface;
-use Vormkracht10\Embedding\Engines\NullEngine;
-use Vormkracht10\Embedding\Engines\OpenAiEngine;
+use UX\Embedding\Engines\EngineInterface;
+use UX\Embedding\Engines\NullEngine;
+use UX\Embedding\Engines\OpenAiEngine;
 
 class EngineManager extends Manager
 {

--- a/src/Engines/EngineInterface.php
+++ b/src/Engines/EngineInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Vormkracht10\Embedding\Engines;
+namespace UX\Embedding\Engines;
 
 interface EngineInterface
 {

--- a/src/Engines/NullEngine.php
+++ b/src/Engines/NullEngine.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Vormkracht10\Embedding\Engines;
+namespace UX\Embedding\Engines;
 
 use Illuminate\Database\Eloquent\Collection;
 

--- a/src/Engines/OpenAiEngine.php
+++ b/src/Engines/OpenAiEngine.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Vormkracht10\Embedding\Engines;
+namespace UX\Embedding\Engines;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;

--- a/src/Events/ModelsFlushed.php
+++ b/src/Events/ModelsFlushed.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Vormkracht10\Embedding\Events;
+namespace UX\Embedding\Events;
 
 use Illuminate\Database\Eloquent\Collection;
 

--- a/src/Events/ModelsImported.php
+++ b/src/Events/ModelsImported.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Vormkracht10\Embedding\Events;
+namespace UX\Embedding\Events;
 
 use Illuminate\Database\Eloquent\Collection;
 

--- a/src/Facades/LaravelEmbed.php
+++ b/src/Facades/LaravelEmbed.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Vormkracht10\Embedding\Facades;
+namespace UX\Embedding\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @see \Vormkracht10\Embedding\LaravelEmbed
+ * @see \UX\Embedding\LaravelEmbed
  */
 class LaravelEmbed extends Facade
 {
     protected static function getFacadeAccessor()
     {
-        return \Vormkracht10\Embedding\LaravelEmbed::class;
+        return \UX\Embedding\LaravelEmbed::class;
     }
 }

--- a/src/Jobs/MakeEmbeddable.php
+++ b/src/Jobs/MakeEmbeddable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Vormkracht10\Embedding\Jobs;
+namespace UX\Embedding\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;

--- a/src/Jobs/RemoveFromEmbed.php
+++ b/src/Jobs/RemoveFromEmbed.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Vormkracht10\Embedding\Jobs;
+namespace UX\Embedding\Jobs;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Database\ModelIdentifier;

--- a/src/Jobs/RemoveableEmbedCollection.php
+++ b/src/Jobs/RemoveableEmbedCollection.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Vormkracht10\Embedding\Jobs;
+namespace UX\Embedding\Jobs;
 
 use Illuminate\Database\Eloquent\Collection;
 

--- a/src/ModelObserver.php
+++ b/src/ModelObserver.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Vormkracht10\Embedding;
+namespace UX\Embedding;
 
 use Closure;
 use Illuminate\Database\Eloquent\Model;

--- a/tests/EmbeddableBootTest.php
+++ b/tests/EmbeddableBootTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Illuminate\Support\Collection;
-use Vormkracht10\Embedding\Tests\Models\EmbeddableTestModel;
+use UX\Embedding\Tests\Models\EmbeddableTestModel;
 
 it('boots a model using the Embeddable trait without a re-entrant boot error', function () {
     // Booting the model runs bootEmbeddable(). On Laravel 11+ registering the

--- a/tests/Models/EmbeddableTestModel.php
+++ b/tests/Models/EmbeddableTestModel.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Vormkracht10\Embedding\Tests\Models;
+namespace UX\Embedding\Tests\Models;
 
 use Illuminate\Database\Eloquent\Model;
-use Vormkracht10\Embedding\Embeddable;
+use UX\Embedding\Embeddable;
 
 class EmbeddableTestModel extends Model
 {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,5 @@
 <?php
 
-use Vormkracht10\Embedding\Tests\TestCase;
+use UX\Embedding\Tests\TestCase;
 
 uses(TestCase::class)->in(__DIR__);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Vormkracht10\Embedding\Tests;
+namespace UX\Embedding\Tests;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Orchestra\Testbench\TestCase as Orchestra;
-use Vormkracht10\Embedding\EmbeddingServiceProvider;
+use UX\Embedding\EmbeddingServiceProvider;
 
 class TestCase extends Orchestra
 {
@@ -13,7 +13,7 @@ class TestCase extends Orchestra
         parent::setUp();
 
         Factory::guessFactoryNamesUsing(
-            fn (string $modelName) => 'Vormkracht10\\Embedding\\Database\\Factories\\'.class_basename($modelName).'Factory'
+            fn (string $modelName) => 'UX\\Embedding\\Database\\Factories\\'.class_basename($modelName).'Factory'
         );
     }
 


### PR DESCRIPTION
## Summary

The package has moved to the **ux-nl** organization. This renames the Composer package, PHP namespace and all branding.

### ⚠️ Breaking changes
- **Composer package**: `vormkracht10/laravel-embeddings` → `ux-nl/laravel-embeddings`
- **PHP namespace**: `Vormkracht10\Embedding` → `UX\Embedding`

Consumers must:
```bash
composer remove vormkracht10/laravel-embeddings
composer require ux-nl/laravel-embeddings
```
and update every `use Vormkracht10\Embedding\...;` import to `use UX\Embedding\...;` (including the `Embeddable` trait, `EmbeddingServiceProvider`, and the `Embedding` facade).

### Also updated
- `homepage`, author (`UX` / `developers@ux.nl`), keyword
- README badges + links, `LICENSE.md` copyright
- `.github/FUNDING.yml` (`github: ux-nl`), issue-template discussion/security links
- config-file comment, phpunit testsuite name
- Regenerated the PHPStan baseline for the new namespace

### Testing
Full suite green locally (4 passed, incl. the boot regression test) and PHPStan clean under the new namespace.

### Post-merge (outside this repo)
- Register `ux-nl/laravel-embeddings` on Packagist (submit repo / webhook).
- Mark the old `vormkracht10/laravel-embeddings` package as abandoned, pointing to the new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)